### PR TITLE
Grafana and Prometheus are moved under the Spring Cloud Gateway service

### DIFF
--- a/code/spring-cloud-metrics-end/docker-compose.yml
+++ b/code/spring-cloud-metrics-end/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       - ./data/prometheus/config:/etc/prometheus/
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
-    ports:
-      - 9090:9090
 
   grafana:
     image: grafana/grafana-oss:8.5.2
@@ -21,8 +19,9 @@ services:
       # Enabled for logging
       - GF_LOG_MODE=console file
       - GF_LOG_FILTERS=alerting.notifier.slack:debug alertmanager:debug ngalert:debug
-    ports:
-      - 3000:3000
+      # Enabled for reverse proxy
+      - GF_SERVER_ROOT_URL=http://localhost:8080/grafana
+      - GF_SERVER_SERVE_FROM_SUB_PATH=true
 
   eureka:
     build: eureka-server-end

--- a/code/spring-cloud-metrics-end/gateway-service-end/src/main/resources/application.yml
+++ b/code/spring-cloud-metrics-end/gateway-service-end/src/main/resources/application.yml
@@ -38,9 +38,22 @@ spring.cloud.gateway.routes:
     uri: http://${app.eureka-server}:8761
     predicates:
       - Path=/eureka/**
+  - id: grafana
+    uri: http://${app.grafana-server}:3000
+    predicates:
+      - Path=/grafana/**
+    filters:
+      - RewritePath=/grafana/(?<remaining>.+), /$\{remaining}
+  - id: prometheus
+    uri: http://${app.prometheus-server}:9090
+    predicates:
+      - Path=/prometheus/**
+    filters:
+      - RewritePath=/prometheus/(?<remaining>.+), /$\{remaining}
 
 ---
 spring.config.activate.on-profile: docker
 server.port: 8080
 app.eureka-server: eureka
-
+app.prometheus-server: prometheus
+app.grafana-server: grafana


### PR DESCRIPTION
Grafana and Prometheus are moved under the Spring Cloud Gateway service for security reasons.

Spring Cloud Gateway configuration reference: https://docs.spring.io/spring-cloud-gateway/reference/spring-cloud-gateway/gatewayfilter-factories/rewritepath-factory.html

In [this](https://github.com/grafana/grafana/issues/16623) post we can see which enviroment variables must be set to allow reverse proxy options.