### PR TITLE
spring-cloud-elk-end: fix error: flood stage disk watermark 95 exceeded

### DIFF
--- a/code/spring-cloud-elk-end/docker-compose.yml
+++ b/code/spring-cloud-elk-end/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
       - xpack.security.enrollment.enabled=false
+      - cluster.routing.allocation.disk.threshold_enabled=false
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
[Reference](https://stackoverflow.com/questions/63880017/elasticsearch-docker-flood-stage-disk-watermark-95-exceeded)  

This seems to be the most straightforward solution